### PR TITLE
Enabled CSRF protection

### DIFF
--- a/src/main/java/org/iseage/ito/config/SecurityConfig.java
+++ b/src/main/java/org/iseage/ito/config/SecurityConfig.java
@@ -56,8 +56,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .permitAll()
                 .logoutSuccessUrl("/login?logout=true")
                 .and()
-            .csrf()
-                .disable();
     }
 
     @Autowired


### PR DESCRIPTION
CSRF protection was disabled in the security config; this is a quick fix to re-enable it.
